### PR TITLE
Fix Node.js installation version mismatch on Windows

### DIFF
--- a/src/main/server/scripts/dependencies/files/node.ts
+++ b/src/main/server/scripts/dependencies/files/node.ts
@@ -221,10 +221,13 @@ export async function install(
 								type: "log",
 								content: `Moving Node.js files to ${binFolder}/${depName}...`,
 							});
+							// Extract version from the URL to handle version updates
+							const versionMatch = url.match(/node-(v\d+\.\d+\.\d+)/);
+							const nodeVersion = versionMatch ? versionMatch[1] : "v22.18.0";
 							const tempFolder = path.join(
 								binFolder,
 								depName,
-								`node-v22.17.1-win-${arch == "amd64" ? "x64" : arch}`,
+								`node-${nodeVersion}-win-${arch == "amd64" ? "x64" : arch}`,
 							);
 							fs.cpSync(tempFolder, path.join(binFolder, depName), {
 								recursive: true,


### PR DESCRIPTION
## Summary
- Fixed Node.js installation error on Windows where the installer was looking for a hardcoded version (v22.17.1) while downloading a different version (v22.18.0)
- Made the version detection dynamic by extracting it from the download URL

## Changes
- Modified `src/main/server/scripts/dependencies/files/node.ts` to dynamically extract the Node.js version from the download URL
- Replaced hardcoded version string with regex-based version extraction

## Problem
The installer was failing with:
```
Error: ENOENT: no such file or directory, lstat 'C:\Users\marti\AppData\Roaming\dione\bin\node\node-v22.17.1-win-x64'
```

This happened because the code downloaded Node.js v22.18.0 but tried to move files from a folder named `node-v22.17.1-win-x64`.

## Solution
Now the code dynamically extracts the version number from the download URL, making it resilient to version updates.

🤖 Generated with [Claude Code](https://claude.ai/code)