### PR TITLE
  Fix conda activate command argument parsing on Windows

### DIFF
--- a/src/main/server/scripts/execute.ts
+++ b/src/main/server/scripts/execute.ts
@@ -463,7 +463,7 @@ async function createVirtualEnvCommands(
 		if (isWindows) {
 			return [
 				`if not exist "${envPath}" (${condaW} tos accept --channel main &&${condaW} create -p "${envPath}" ${pythonArg} -y)`,
-				`call ${condaW} activate "${envPath}" ${middle} && call ${condaW} deactivate`,
+				`call ${condaW} activate "${envPath}" && ${middle} && call ${condaW} deactivate`,
 			];
 		}
 		// for linux and mac


### PR DESCRIPTION
## Description
Fixes an issue where the `conda activate` command was incorrectly trying to pass multiple arguments when it should only receive the environment path.  
Previously, user commands were being passed as arguments to `conda activate` instead of being executed separately after environment activation.

## Related Issues
Resolves command execution issues where conda environments fail to activate properly on Windows when additional commands need to be run.

## Type of Change
- [x] 🐛 Bug fix

## Implementation Details
Updated the command structure in `src/main/server/scripts/execute.ts` to properly separate:

1. Conda environment activation with only the environment path  
2. User commands execution after successful activation  
3. Environment deactivation  

**Before:**  
```bat
call conda activate "env_path" user_commands && call conda deactivate
```

**After:**
```bat
call conda activate "env_path" && user_commands && call conda deactivate
```

## Testing
* Manual testing performed
* TypeScript compilation verified
* Test environment: local development

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] No linting errors
- [x] No security vulnerabilities

### Testing
- [x] All existing tests pass
- [x] TypeScript compilation successful

### Review
- [x] Self-reviewed the code
- [x] PR description is clear and complete

## Additional Notes
This fix ensures that conda environments activate correctly on Windows when users need to run additional commands (e.g., `cd`) after activation. The issue was causing conda to interpret user commands as arguments to the activate command rather than as separate commands to execute within the activated environment.